### PR TITLE
VLM slots: structured tool calling and prefix caching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,12 @@ OpenAI-compatible LLM/VLM server for Intel hardware. NPU-first.
 - `nollama.py` — Flask server, DeviceSlot class per device, auto-detects VLM/LLM from config.json
 - NPU: LLMPipeline with MAX_PROMPT_LEN=4096, streaming via SSE
 - GPU: VLMPipeline (images) or LLMPipeline (text). Both stream as of openvino-genai 2026.1 — verified on Arc 140V iGPU.
-- Prefix (KV) caching: **default on** for GPU/CPU **LLM** slots — they load via the
-  continuous-batching backend (`LLMPipeline(..., scheduler_config=SchedulerConfig(
-  enable_prefix_caching=True, cache_size=slot.kv_pool_gb))`). A repeated prompt prefix (an
+- Prefix (KV) caching: **default on** for GPU/CPU **LLM and VLM** slots — they load via the
+  continuous-batching backend (`LLMPipeline/VLMPipeline(..., scheduler_config=SchedulerConfig(
+  enable_prefix_caching=True, cache_size=slot.kv_pool_gb))`). VLMPipeline honoring
+  scheduler_config was verified 2026-08-18 on 2026.3 release (140V: ~9k-token prefix
+  21.7s→3.9s TTFT) and 2026.4 nightly (B60: 33k tokens 54.5s→1.3s) — the earlier
+  "CB backend is LLM-only" note was stale. A repeated prompt prefix (an
   agent's fixed system prompt + tool schemas, identical every turn) is prefilled once, not
   every turn — measured ~47× faster on a cached turn (24.4s→0.5s for a ~2k-token prefix on
   the 285K CPU). Auto-invalidated by any prefix change (no staleness). `--no-prompt-cache`
@@ -18,9 +21,10 @@ OpenAI-compatible LLM/VLM server for Intel hardware. NPU-first.
   the model's KV geometry (`AUTO_KV_TOKENS`) — sized from the *total* budget (not free RAM)
   so it's stable across restarts/reloads; the CB backend grows into it rather than
   allocating upfront, but prefix-cached blocks are never released, hence the fraction.
-  `--cache-size-gb N` pins it (skips auto). NPU and VLM slots keep the
-  plain pipeline (NPU has no CB path; it keeps MAX_PROMPT_LEN). Falls back to the plain
-  pipeline with a warning if a device can't build the CB backend. `--prewarm <file>`
+  `--cache-size-gb N` pins it (skips auto). NPU slots keep the
+  plain pipeline (no CB path; NPU keeps MAX_PROMPT_LEN). Falls back to the plain
+  pipeline with a warning if a device or runtime can't build the CB backend.
+  Prewarm/prompt-capture is still LLM-only (VLM prewarm untested — see NEXT-STEPS). `--prewarm <file>`
   prefills a saved agent prompt at startup (the file auto-captures the first big prompt
   served via `_maybe_capture_prewarm` — on both the OpenAI and Ollama chat paths — so: run
   once → restart with `--prewarm`) so even the first turn is a cache hit instead of a cold
@@ -87,8 +91,10 @@ OpenAI-compatible LLM/VLM server for Intel hardware. NPU-first.
   projection stack, ~288 GB across 48 layers × 3. Measured: **400 GB of Windows pagefile
   (on 128 GB RAM) succeeded**, 200 GB did not (#19, Dmitriy Teteruk). Weight format is
   irrelevant to this stage — the blowup is before quantization.
-- Tool calling: **GPU/iGPU + CPU** (gated by `_tools_supported`, i.e.
-  `device_name in ("GPU","CPU")`); the **NPU is excluded** — it has a hard prompt cap and
+- Tool calling: **GPU/iGPU + CPU**, on both LLM and VLM slots (VLM tool turns —
+  including images alongside tools — added 2026-08-18; buffered like LLM tool turns,
+  generated through the VLM pipeline). Gated by `_tools_supported`, i.e.
+  `device_name in ("GPU","CPU")`; the **NPU is excluded** — it has a hard prompt cap and
   small NPU-class models can't drive agent loops, so when the NPU serves the request we
   ignore `tools` and answer as plain chat. `/api/show` advertises the `tools` capability only
   for GPU/CPU slots (so Copilot won't offer NPU models for agent mode). CPU is viable for

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -45,14 +45,40 @@ the docs — this file is only what's still open.
   the same gate Qwen3.8 is already waiting on. VLM slots get no prefix
   cache (the CB backend is LLM-only), so that win does not arrive with this.
 
-- **Glimmer lost structured tool calling in the reroute.** On the optimum
-  path Glimmer was `model_type="llm"` and tool turns went through
-  `parse_tool_calls`; on GenAI it is a VLM slot, and the VLM branch of
-  `chat_completions` streams text without ever parsing tool calls — the ATEM
-  XML now reaches the client raw. That's a pre-existing gap for *all* VLM
-  slots (Qwen3-VL has it too), Glimmer just makes it visible because it's an
-  agent model. Fix is "parse tool calls on the VLM path", a separate feature;
-  until then agent use of Glimmer arguably still wants `--backend optimum`.
+- **Branch `vlm-tool-calling`: VLM slots are agent-grade — review & merge.**
+  Two changes, both verified end-to-end 2026-08-18:
+
+  1. **Tool calling on VLM slots** (both API surfaces; buffered like LLM
+     tool turns; images may ride along with tools). Qwen3.5-4B on the 140V
+     and Glimmer on the B60 both return structured
+     `get_weather({"city":"Oslo"})` with `finish_reason=tool_calls`;
+     Glimmer's reasoning stays in `<think>` with no channel leak
+     (`_AtemPlainFilter` also closes the think block at
+     `<atem:function_calls>` so the tool XML reaches `parse_tool_calls`).
+     This un-does the one regression the GenAI reroute had — Glimmer agent
+     use no longer wants `--backend optimum`.
+  2. **Prefix caching on VLM slots.** VLMPipeline honors `scheduler_config`
+     — the long-standing "CB backend is LLM-only" belief was stale. Verified
+     on 2026.3 *release* (140V, ~9k-token prefix 21.7s→3.9s TTFT) and the
+     2026.4 nightly (B60/Glimmer, 33k-token prefix 53.7s→1.4s through
+     NoLlama's serving path). Runtimes that reject the property fall back to
+     the plain pipeline with a log line, like the LLM branch.
+
+  Honest observations from the measurements:
+  - **CB VLM prefill is slower cold**: the same 33k prompt prefilled in
+    ~8.7s on the plain pipeline vs 53.7s under CB (then 1.4s per repeat).
+    Agents win from turn two; one-shot prompts pay more once.
+    `--no-prompt-cache` restores the plain pipeline if that bites.
+  - The plain pipeline **OOM'd on the first 33k-token request** on the B60
+    (16 GB USM allocation failed; the immediate retry succeeded). Under CB
+    the same request completed first try. Unexplained — file upstream if it
+    reproduces.
+  - **Prewarm is still LLM-only** (`_maybe_capture_prewarm` and the prewarm
+    prefill gate on `model_type == "llm"`). With VLM caching working, wiring
+    prewarm up for VLM slots is the natural follow-up — it converts the one
+    remaining cold 53.7s prefill into a startup cost.
+  - The "minutes of prefill" worry for agent prompts was wrong for the B60
+    class: 33k tokens prefill in ~9s on the plain pipeline.
 
 - **Loading a big model stages through host memory first.** Watched on the B60
   (17 GB Glimmer): shared GPU memory ramps to near its 16 GB ceiling and holds

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -243,9 +243,13 @@ What to know before switching:
 - Needs the **nightly runtime** (`install.ps1 -Nightly`) until OpenVINO
   2026.4 ships as a release — Intel exported it with a 2026.4 build and the
   card wants 2026.3.1+ with a genai pre-release. Same gate as Qwen3.8-27B.
-- It lands on a **VLM slot**: no prefix cache / prewarm, and tool calls are
-  **not parsed into structured `tool_calls`** (they pass through as text) —
-  the optimum path did parse them. Images are untested on Glimmer.
+- It lands on a **VLM slot** — which since 2026-08-18 means **tool calling
+  works** (structured `tool_calls` on both API surfaces, verified with
+  Glimmer on the B60) and **prefix caching works** (VLMPipeline honors
+  `scheduler_config` on 2026.3+; measured on the B60: a 33k-token prefix
+  went 54.5s → 1.3s TTFT on the repeat turn — what an agent's fixed system
+  prompt does every turn). Prewarm is still LLM-only, and images are
+  untested on Glimmer.
 - `--backend optimum` still forces the old path (needs `venv-optimum/`).
 
 ## Brand-new architectures: the optimum backend
@@ -400,9 +404,10 @@ Know what you are signing up for before you pull 15.7 GB:
 
 - Intel labels the export **experimental / "not fully validated with
   OpenVINO"**, and nightly wheels change daily.
-- It is a **VLM**, so it lands on `VLMPipeline` — **no prefix cache, no
-  prewarm**. For agent work that means every turn re-prefills the system
-  prompt. Fine for chat and vision; painful for OpenClaw.
+- It is a **VLM**, so it lands on `VLMPipeline`. Prefix caching now works
+  on VLM slots (verified 2026-08-18 on 2026.3 release and the 2026.4
+  nightly), so agent turns reuse the prefilled system prompt; prewarm is
+  still LLM-only, so the *first* turn after a start pays the full prefill.
 - It is **dense**, not MoE, so `--offload-ratio` does nothing for it. The
   15.7 GB of weights must be resident.
 - That rules out a stock 16 GB Arc 140V. It wants a 24 GB card (Arc B60)

--- a/nollama.py
+++ b/nollama.py
@@ -1239,7 +1239,31 @@ class DeviceSlot:
             VLMPipe = getattr(ovg, "VLMPipeline", None)
             if VLMPipe is None:
                 raise RuntimeError("No VLMPipeline in this openvino_genai build.")
-            self.pipe = VLMPipe(str(model_dir), device=self.device_id, **offload)
+            if PROMPT_CACHE and self.kv_pool_gb and self.device_name in ("GPU", "CPU"):
+                # VLMPipeline honors scheduler_config on current runtimes —
+                # measured 2026-08-18: 2026.3 release (140V, ~9k-token prefix
+                # 21.7s -> 3.9s TTFT) and 2026.4 nightly (B60, 33k-token
+                # prefix 54.5s -> 1.3s). The old "CB backend is LLM-only"
+                # belief was stale. A runtime that rejects the property falls
+                # back to the plain pipeline, same pattern as the LLM branch.
+                try:
+                    sc = ovg.SchedulerConfig()
+                    sc.enable_prefix_caching = True
+                    sc.cache_size = self.kv_pool_gb
+                    self.pipe = VLMPipe(str(model_dir), device=self.device_id,
+                                        scheduler_config=sc, **offload)
+                    src = "" if PROMPT_CACHE_GB is not None else \
+                        ", auto-sized — pin with --cache-size-gb"
+                    print(f"  [{self.device_name}] prefix caching on "
+                          f"({self.kv_pool_gb} GB KV pool{src})", flush=True)
+                except Exception as e:
+                    print(f"  [{self.device_name}] prefix caching unavailable "
+                          f"({e}); using plain pipeline", flush=True)
+                    self.pipe = VLMPipe(str(model_dir), device=self.device_id,
+                                        **offload)
+            else:
+                self.pipe = VLMPipe(str(model_dir), device=self.device_id,
+                                    **offload)
         else:
             # NPU has a default prompt limit of 1024 tokens — raise it
             if self.device_name == "NPU":
@@ -1287,7 +1311,11 @@ class DeviceSlot:
         session eventually owns the whole pool, hence the headroom fraction
         (see AUTO_KV_HEADROOM_SHARE).
         """
-        if not (PROMPT_CACHE and not vlm and self.supports_prefix_cache
+        # VLM slots size a pool too: openvino_genai honors scheduler_config
+        # on VLMPipeline (verified on 2026.3 release and the 2026.4 nightly;
+        # a runtime that rejects it falls back to the plain pipeline at load,
+        # leaving the pool unused).
+        if not (PROMPT_CACHE and self.supports_prefix_cache
                 and self.device_name in ("GPU", "CPU")):
             self.kv_pool_gb = 0
             return
@@ -1795,24 +1823,33 @@ class _AtemPlainFilter:
 
     Same surface as _AtemStreamFilter: to=self content -> <think>...</think>,
     to=user -> plain text; ATEM XML tool calls are ordinary text and pass
-    through to parse_tool_calls. Necessarily more fragile than the marker
-    filter — 'assistant to=user' could legitimately occur inside reasoning
-    content — but the alternative is raw channel soup in every client.
+    through to parse_tool_calls. A tool turn ends in a to=<name> channel
+    rather than to=user, so the think block also closes at the first
+    <atem:function_calls> — any 'assistant to=<name>' header glued in front
+    of it stays hidden inside the think block (channel names are glued to
+    their content; there is no delimiter to split them out reliably).
+    Necessarily more fragile than the marker filter — 'assistant to=user'
+    could legitimately occur inside reasoning content — but the alternative
+    is raw channel soup in every client.
     """
 
     _OPENERS = ("to=self", "to=user")
     _SWITCH = "assistant to=user"
+    _TOOL_XML = "<atem:function_calls>"
 
     def __init__(self):
         self._buf = ""
         self._state = "header"  # header -> think | answer
 
     def _held_tail(self):
-        """Length of the buffer tail that could be the start of the switch."""
-        for ln in range(min(len(self._buf), len(self._SWITCH) - 1), 0, -1):
-            if self._SWITCH.startswith(self._buf[-ln:]):
-                return ln
-        return 0
+        """Length of the buffer tail that could be the start of a marker."""
+        best = 0
+        for mk in (self._SWITCH, self._TOOL_XML):
+            for ln in range(min(len(self._buf), len(mk) - 1), 0, -1):
+                if mk.startswith(self._buf[-ln:]):
+                    best = max(best, ln)
+                    break
+        return best
 
     def feed(self, text):
         self._buf += text
@@ -1829,15 +1866,31 @@ class _AtemPlainFilter:
                     else:
                         self._state = "answer"
                     continue
-                if not lead or any(o.startswith(lead) for o in self._OPENERS):
+                # Tool channel straight from the header (no reasoning first):
+                # the name ends where its ATEM XML starts — '<' delimits.
+                m = re.match(r"to=[\w.]+(?=<)", lead)
+                if m:
+                    self._buf = lead[m.end():]
+                    self._state = "answer"
+                    continue
+                if (not lead or any(o.startswith(lead) for o in self._OPENERS)
+                        or re.fullmatch(r"to=[\w.]*", lead)):
                     break  # could still grow into a channel header — hold
                 self._state = "answer"  # no header at all — pass through
                 continue
             if self._state == "think":
                 i = self._buf.find(self._SWITCH)
-                if i >= 0:
+                j = self._buf.find(self._TOOL_XML)
+                if i >= 0 and (j < 0 or i < j):
                     out.append(self._buf[:i] + "</think>\n")
                     self._buf = self._buf[i + len(self._SWITCH):]
+                    self._state = "answer"
+                    continue
+                if j >= 0:
+                    # Tool call: close the think block and let the ATEM XML
+                    # flow through to parse_tool_calls (marker kept).
+                    out.append(self._buf[:j] + "</think>\n")
+                    self._buf = self._buf[j:]
                     self._state = "answer"
                     continue
                 held = self._held_tail()
@@ -2310,7 +2363,8 @@ def _sse_replay(completion_id, created, model, message, finish_reason):
     yield "data: [DONE]\n\n"
 
 
-def _sse_tool_stream(slot, raw_messages, gen, tools, completion_id, created, t0):
+def _sse_tool_stream(slot, raw_messages, gen, tools, completion_id, created, t0,
+                     vlm=None):
     """Buffered tool turn, streamed with keep-alive frames.
 
     A tool turn must be fully generated before we can emit a structured
@@ -2320,12 +2374,18 @@ def _sse_tool_stream(slot, raw_messages, gen, tools, completion_id, created, t0)
     until it finishes, then replay the parsed result. Without this the client
     sees nothing during prefill and aborts (and OpenVINO can't cancel a blocked
     prefill, so the abandoned generation keeps churning).
+
+    vlm: (text_prompt, images) when the slot is a VLM — the same buffered
+    turn, generated through the VLM pipeline instead of ChatHistory.
     """
     result = {}
 
     def _run():
         try:
-            result["text"] = slot.generate_llm(raw_messages, gen)
+            if vlm is not None:
+                result["text"] = slot.generate_vlm(vlm[0], vlm[1], gen)
+            else:
+                result["text"] = slot.generate_llm(raw_messages, gen)
         except Exception as e:  # noqa: BLE001 — surfaced to the client below
             result["error"] = e
 
@@ -2356,7 +2416,7 @@ def _sse_tool_stream(slot, raw_messages, gen, tools, completion_id, created, t0)
     if result.get("error") is not None:
         err = explain_genai_error(result["error"], slot)
         print(f"{datetime.now():%H:%M:%S} !! [{slot.device_name}] "
-              f"LLM error: {err}", flush=True)
+              f"{'VLM' if vlm is not None else 'LLM'} error: {err}", flush=True)
         yield ("data: " + json.dumps({
             "id": completion_id, "object": "chat.completion.chunk",
             "created": created, "model": slot.model_name,
@@ -2734,6 +2794,16 @@ def chat_completions():
 
     # --- VLM path ---
     if slot.model_type == "vlm":
+        # Tool turns are buffered like the LLM path's (structured tool_calls
+        # need the whole generation); images alongside tools are allowed — a
+        # screenshot plus tool specs is a legitimate agent turn.
+        if stream and tools_active:
+            return Response(
+                _sse_tool_stream(slot, raw_messages, gen, tools, completion_id,
+                                 created, t0, vlm=(text_prompt, images)),
+                mimetype="text/event-stream",
+                headers={"X-Device": slot.device_name, "X-Model": slot.model_name},
+            )
         if stream:
             return Response(
                 slot.stream_vlm(text_prompt, images, gen, completion_id, created, t0),
@@ -2751,10 +2821,25 @@ def chat_completions():
         print(f"{datetime.now():%H:%M:%S} -> [{slot.device_name}] "
               f"{len(text)} chars in {elapsed:.1f}s", flush=True)
 
+        tool_calls = []
+        if tools_active:
+            text, tool_calls = parse_tool_calls(text, tools)
+            if tool_calls:
+                print(f"{datetime.now():%H:%M:%S} -> [{slot.device_name}] "
+                      f"{len(tool_calls)} tool call(s): "
+                      f"{', '.join(tc['function']['name'] for tc in tool_calls)}",
+                      flush=True)
+        if tool_calls:
+            message = {"role": "assistant", "content": text or None, "tool_calls": tool_calls}
+            finish_reason = "tool_calls"
+        else:
+            message = {"role": "assistant", "content": text}
+            finish_reason = "stop"
+
         resp = jsonify({
             "id": completion_id, "object": "chat.completion",
             "created": created, "model": slot.model_name,
-            "choices": [{"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}],
+            "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
             "usage": {"prompt_tokens": -1, "completion_tokens": -1, "total_tokens": -1},
         })
         resp.headers["X-Device"] = slot.device_name
@@ -2952,8 +3037,9 @@ def ollama_chat():
     # we render tool specs into the prompt; on NPU/CPU we ignore `tools`.
     tools_active = bool(tools) and _tools_supported(slot)
     if tools_active:
-        # Tool turns are text-only: render tool specs + prior calls into the
-        # prompt. (Images + tools simultaneously is not a supported path.)
+        # Render tool specs + prior calls into the prompt. Images ride along
+        # untouched — a screenshot plus tool specs is a legitimate agent turn
+        # on a VLM slot.
         internal_messages = prepare_messages_for_tools(ollama_messages, tools)
     elif tools:
         print(f"{datetime.now():%H:%M:%S} -- [{slot.device_name}] [Ollama] "
@@ -3012,9 +3098,26 @@ def ollama_chat():
         print(f"{datetime.now():%H:%M:%S} -> [{slot.device_name}] [Ollama] "
               f"{len(text)} chars in {elapsed:.1f}s", flush=True)
 
+        message = {"role": "assistant", "content": text}
+        if tools_active:
+            text, tool_calls = parse_tool_calls(text, tools)
+            message["content"] = text
+            if tool_calls:
+                # Ollama shape: arguments are an object, not a JSON string.
+                message["tool_calls"] = [{
+                    "function": {
+                        "name": tc["function"]["name"],
+                        "arguments": json.loads(tc["function"]["arguments"]),
+                    }
+                } for tc in tool_calls]
+                print(f"{datetime.now():%H:%M:%S} -> [{slot.device_name}] [Ollama] "
+                      f"{len(tool_calls)} tool call(s): "
+                      f"{', '.join(tc['function']['name'] for tc in tool_calls)}",
+                      flush=True)
+
         return jsonify({
             "model": slot.model_name,
-            "message": {"role": "assistant", "content": text},
+            "message": message,
             "done": True,
             "total_duration": int(elapsed * 1e9),
         })


### PR DESCRIPTION
Tool calling: VLM tool turns were rendered into the prompt but never parsed back — the VLM branches of both API surfaces returned before parse_tool_calls, so agent clients got tool XML as text. Now VLM slots buffer tool turns exactly like LLM slots (_sse_tool_stream gains a vlm mode; non-streaming paths parse and shape tool_calls on both the OpenAI and Ollama surfaces). Images may ride along with tools. _AtemPlainFilter additionally closes Glimmer's think block at <atem:function_calls> and recognises a tool channel straight from the header, so the ATEM XML flows intact to parse_tool_calls.

Prefix caching: VLMPipeline honors scheduler_config — the "CB backend is LLM-only" belief was stale. VLM slots on GPU/CPU now load through the continuous-batching backend with prefix caching, auto-sized like LLM slots, falling back to the plain pipeline when a runtime rejects the property.

Verified 2026-08-18:
- Qwen3.5-4B, Arc 140V, 2026.3 release: structured get_weather calls on OpenAI (non-stream + buffered stream) and Ollama surfaces; raw probe ~9k-token prefix 21.7s -> 3.9s TTFT.
- Muse Glimmer 30B, Arc Pro B60, 2026.4 nightly, through the serving path: structured tool calls with reasoning framed in <think>, no channel leak; 33k-token prefix 53.7s -> 1.4s TTFT on the repeat turn.

Trade-offs recorded in NEXT-STEPS: CB VLM prefill is slower cold (8.7s plain vs 53.7s CB on the same 33k prompt) and wins from turn two; prewarm remains LLM-only; the plain pipeline OOM'd on a first 33k request where CB did not.